### PR TITLE
add env var validation, add curl failure flag

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,11 +1,23 @@
 #!/bin/bash
 set -ex
 
-# TODO: Update to handle curl errors (unable to upload / network issues)
+# Required parameters
+if [ -z "${nowsecure_api_token}" ] ; then
+  echo " [!] Missing required input: nowsecure_api_token"
+  exit 1
+fi
+
+if [ -z "${upload_path}" ] ; then
+  echo " [!] Missing required input: upload_path"
+  exit 1
+fi
+
 
 if [[ $nowsecure_group_id ]]
 then
-  output=$(curl -H "Authorization: Bearer $nowsecure_api_token" -X POST https://lab-api.nowsecure.com/build/?group=$nowsecure_group_id --http1.1 --data-binary @$upload_path)
+  output=$(curl -H "Authorization: Bearer $nowsecure_api_token" -X POST https://lab-api.nowsecure.com/build/?group=$nowsecure_group_id --http1.1 --data-binary @$upload_path -f)
 else
-  output=$(curl -H "Authorization: Bearer $nowsecure_api_token" -X POST https://lab-api.nowsecure.com/build/ --http1.1 --data-binary @$upload_path)
+  output=$(curl -H "Authorization: Bearer $nowsecure_api_token" -X POST https://lab-api.nowsecure.com/build/ --http1.1 --data-binary @$upload_path -f)
 fi
+
+exit $?


### PR DESCRIPTION
Add variable validation as backup for Bitrise step config, and add curl's `-f` flag to capture failure and exit appropriately. 